### PR TITLE
Add warnings-as-errors check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install (deps)
         run: mix deps.get
 
+      - name: Compilation
+        run: mix compile --force --warnings-as-errors
+
       - name: Run Tests
         run: mix test
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,5 @@
+if System.get_env("CI") == "true" do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 ExUnit.start()


### PR DESCRIPTION
Consider warnings as errors in our CI pipeline, for both real code and test code. This is to help keep unintentional bugs out of code.