### PR TITLE
Only track watched projects.

### DIFF
--- a/lib/ground_control_web/components/repository_component.ex
+++ b/lib/ground_control_web/components/repository_component.ex
@@ -29,7 +29,7 @@ defmodule GroundControlWeb.RepositoryComponent do
         <div class="flex flex-auto flex-row justify-between items-center content-center">
           <span class="text-2xl title-font font-medium"><%= @repo["name"] %></span>
 
-          <span class="text-gray-300 title-font lowercase font-medium"><%= @repo["sha"] %></span>
+          <a href="https://github.com/<%= @repo["owner"] %>/<%= @repo["name"] %>/commit/<%= @repo["sha"] %>" target="_blank" class="text-gray-300 title-font lowercase font-medium"><%= @repo["sha"] %></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Right now any project in the org using the CI `Deploy {env}` will get watched (see: CopyCat), this prevents that. It also makes the SHA linkable.